### PR TITLE
Cleanup admin mode and add utility helpers

### DIFF
--- a/addon/__init__.py
+++ b/addon/__init__.py
@@ -54,11 +54,7 @@ class OBJECT_OT_BFEX_preferences(bpy.types.Operator):
 
         return {'FINISHED'}
 
-# Utilities 
-def set_object_mode(obj, mode):
-    bpy.context.view_layer.objects.active = obj
-    bpy.ops.object.mode_set(mode=mode)
-
+# Utilities
 def get_addon_name():
     return __name__.split('.')[0]
     
@@ -270,11 +266,6 @@ def register():
         update=update_checkboxes
     )
     
-    bpy.types.Scene.run_as_admin = bpy.props.BoolProperty(
-        name="Open Results When Finish",
-        default=False,
-        update=update_checkboxes
-    )   
     
     bpy.types.Scene.show_constraint_points = bpy.props.BoolProperty(
         name="Show Constraint Points",
@@ -299,12 +290,6 @@ def register():
         default=False,
         description="Display arrows indicating force directions"
     )
-    bpy.types.Scene.show_scale_section = bpy.props.BoolProperty(
-        name="Show Scale Section",
-        default=False,
-        description="Expand or collapse the scale section"
-    )
-
     bpy.types.Scene.scale_property = bpy.props.EnumProperty(
         name="Scale Property",
         items=[
@@ -511,7 +496,6 @@ def unregister():
         "fixation_z",
         "display_existing_results",
         "open_results_when_finish",
-        "run_as_admin",
         "show_constraint_points",
         "show_contact_points",
         "show_attachment_areas",

--- a/addon/export_meshes.py
+++ b/addon/export_meshes.py
@@ -6,6 +6,7 @@ import bpy
 import json
 import mathutils
 from bpy.types import Operator
+from .utils import to_world_coordinates
 
 class VIEW3D_OT_ExportMeshesOperator(Operator):
     bl_idname = "view3d.export_meshes"
@@ -99,7 +100,7 @@ class VIEW3D_OT_ExportMeshesOperator(Operator):
                                 # Use the first vertex in the group
                                 vertex_index = vertices_indices[0]
                                 vertex_co = main_object.data.vertices[vertex_index].co.copy()
-                                world_co = main_object.matrix_world @ vertex_co
+                                world_co = to_world_coordinates(main_object, vertex_co)
                                 
                                 # Create the fixation entry
                                 fixation_entry = {
@@ -132,7 +133,7 @@ class VIEW3D_OT_ExportMeshesOperator(Operator):
                                 # Create the load entry
                                 for vertex_index in vertices_indices:
                                     vertex_co = main_object.data.vertices[vertex_index].co.copy()
-                                    world_co = main_object.matrix_world @ vertex_co
+                                    world_co = to_world_coordinates(main_object, vertex_co)
                                     
                                     load_entry = {
                                         "name": vgroup.name.replace("_load", ""),

--- a/addon/menu.py
+++ b/addon/menu.py
@@ -329,7 +329,6 @@ class VIEW3D_PT_BFEXMenu_PT(bpy.types.Panel):
 
         col1.prop(context.scene, "display_existing_results", text="Display Existing Results")
         col1.prop(context.scene, "open_results_when_finish", text="Open Results When Finish")
-        col1.prop(context.scene, "run_as_admin", text="Run as Admin")
 
         col2.operator("view3d.export_meshes", text="Export files", icon='EXPORT')
         col2.operator("view3d.run_fossils", text="Run Fossils", icon='PLAY')

--- a/addon/run_fossils.py
+++ b/addon/run_fossils.py
@@ -5,7 +5,6 @@ import bpy
 import os
 import subprocess
 import platform
-import ctypes
 from bpy.types import Operator
 
 
@@ -41,15 +40,12 @@ class VIEW3D_OT_RunFossilsOperator(Operator):
             args.append("--nogui")
         
         try:
-            if platform.system() == 'Windows' and context.scene.run_as_admin:
-                args = ' '.join(args)
-                ctypes.windll.shell32.ShellExecuteW(None, "runas", fossils_path, args, python_file_path, 1)
-            else:
-                if platform.system() == 'Windows':
-                    subprocess.Popen([fossils_path] + args, creationflags=subprocess.CREATE_NEW_CONSOLE, cwd=os.path.dirname(python_file_path))
-                elif platform.system() == 'Linux':
-                    subprocess.Popen(['xterm', '-e', fossils_path] + args, cwd=os.path.dirname(python_file_path))
-        
+            cmd = [fossils_path] + args
+            if platform.system() == 'Windows':
+                subprocess.Popen(cmd, creationflags=subprocess.CREATE_NEW_CONSOLE, cwd=os.path.dirname(python_file_path))
+            elif platform.system() == 'Linux':
+                subprocess.Popen(['xterm', '-e'] + cmd, cwd=os.path.dirname(python_file_path))
+            
             self.report({'INFO'}, f"External program '{fossils_path}' started successfully with Python file: '{python_file_path}'")
         except Exception as e:
             self.report({'ERROR'}, f"Error starting external program: {e}. Be sure to have the correct path to Fossils in the preferences. Command: {fossils_path} {args}")

--- a/addon/submit_focal.py
+++ b/addon/submit_focal.py
@@ -5,6 +5,7 @@ import bpy
 from bpy.types import Operator
 from mathutils import Vector
 import mathutils
+from .utils import to_world_coordinates
 
 
 class VIEW3D_OT_SubmitFocalPointOperator(Operator):
@@ -43,10 +44,7 @@ class VIEW3D_OT_SubmitFocalPointOperator(Operator):
             self.report({'ERROR'}, "Please select at least one vertex as the Focal Point.")
             return {'CANCELLED'}
         def get_transformed_coordinates(obj, coordinates):
-
-            matrix_world = obj.matrix_world
-            original_vector = mathutils.Vector(coordinates)
-            transformed_vector = matrix_world @ original_vector
+            transformed_vector = to_world_coordinates(obj, mathutils.Vector(coordinates))
             return transformed_vector.x, transformed_vector.y, transformed_vector.z
         
         # Calculate the average coordinates of the selected vertices

--- a/addon/submit_focal_load.py
+++ b/addon/submit_focal_load.py
@@ -5,6 +5,7 @@ from bpy.types import Operator
 import mathutils
 import bpy
 import json
+from .utils import to_world_coordinates
 
 class View3D_OT_SubmitFocalLoad(Operator):
     bl_idname = "view3d.submit_focal_load"
@@ -24,12 +25,6 @@ class View3D_OT_SubmitFocalLoad(Operator):
             self.report({'ERROR'}, "No vertices selected.")
             return {'CANCELLED'}
 
-        def get_transformed_coordinates(obj, coordinates):
-            matrix_world = obj.matrix_world
-            original_vector = mathutils.Vector(coordinates)
-            transformed_vector = matrix_world @ original_vector
-            return transformed_vector
-
         if len(selected_vertices_indices) > 1:
             # Calculate the centroid of selected vertices
             sum_coords = mathutils.Vector((0, 0, 0))
@@ -37,12 +32,12 @@ class View3D_OT_SubmitFocalLoad(Operator):
                 sum_coords += active_object.data.vertices[vertex_index].co
             centroid = sum_coords / len(selected_vertices_indices)
             # Transform centroid to global coordinates
-            transformed_centroid = get_transformed_coordinates(active_object, centroid)
+            transformed_centroid = to_world_coordinates(active_object, centroid)
             loads_focal_str = json.dumps([transformed_centroid.x, transformed_centroid.y, transformed_centroid.z])
         else:
             # Handle the single vertex case (or no vertex, which is caught earlier)
             vertex_coords = active_object.data.vertices[selected_vertices_indices[0]].co
-            transformed_coords = get_transformed_coordinates(active_object, vertex_coords)
+            transformed_coords = to_world_coordinates(active_object, vertex_coords)
             loads_focal_str = json.dumps([transformed_coords.x, transformed_coords.y, transformed_coords.z])
         
         context.scene.loads_focal = loads_focal_str

--- a/addon/submit_load.py
+++ b/addon/submit_load.py
@@ -4,7 +4,8 @@
 import bpy
 from bpy.types import Operator
 import mathutils
-import json  
+import json
+from .utils import to_world_coordinates
 
 class View3D_OT_Submit_load(Operator):
     bl_idname = "view3d.submit_load"
@@ -54,7 +55,7 @@ class View3D_OT_Submit_load(Operator):
         if context.scene.load_input_method == 'VERTICES':
             # Get the selected vertex position
             selected_vertex = mesh.vertices[selected_vertices_indices[0]]
-            selected_vertex_position = active_object.matrix_world @ selected_vertex.co.copy()
+            selected_vertex_position = to_world_coordinates(active_object, selected_vertex.co.copy())
             
             # Get the focal point
             if not hasattr(context.scene, 'loads_focal') or context.scene.loads_focal == "":

--- a/addon/utils.py
+++ b/addon/utils.py
@@ -1,0 +1,23 @@
+"""Utility functions used across the BFEX add-on."""
+
+import bpy
+from mathutils import Vector
+
+
+def set_object_mode(obj: bpy.types.Object, mode: str) -> None:
+    """Safely set the mode of ``obj``.
+
+    Parameters
+    ----------
+    obj: bpy.types.Object
+        The object to operate on.
+    mode: str
+        Target mode (e.g. 'OBJECT', 'EDIT').
+    """
+    bpy.context.view_layer.objects.active = obj
+    bpy.ops.object.mode_set(mode=mode)
+
+
+def to_world_coordinates(obj: bpy.types.Object, vector: Vector) -> Vector:
+    """Return ``vector`` transformed to world space using ``obj``'s matrix."""
+    return obj.matrix_world @ vector

--- a/addon/visual_elements.py
+++ b/addon/visual_elements.py
@@ -7,6 +7,7 @@ import random
 from bpy.types import Operator
 from mathutils import Vector
 import bmesh
+from .utils import to_world_coordinates
 
 class VIEW3D_OT_VisualElementsOperator(Operator):
     bl_idname = "view3d.visual_elements"
@@ -130,7 +131,7 @@ class VIEW3D_OT_VisualElementsOperator(Operator):
                             
                             # Crear un punto para representar el centro del músculo
                             # Usar el centro del objeto en lugar de buscar un grupo de vértices
-                            muscle_center = muscle_obj.matrix_world @ Vector((0, 0, 0))
+                            muscle_center = to_world_coordinates(muscle_obj, Vector((0, 0, 0)))
                             
                             # Calcular dirección desde el centro del músculo hacia el punto focal
                             direction = (focal_point - muscle_center).normalized()
@@ -156,8 +157,10 @@ class VIEW3D_OT_VisualElementsOperator(Operator):
                 if group.name.startswith("contact_"):
                     vertices_indices = [v.index for v in main_object.data.vertices 
                                        if group.index in [g.group for g in v.groups]]
-                    vertex_coordinates_global = [main_object.matrix_world @ main_object.data.vertices[i].co 
-                                               for i in vertices_indices]
+                    vertex_coordinates_global = [
+                        to_world_coordinates(main_object, main_object.data.vertices[i].co)
+                        for i in vertices_indices
+                    ]
                     
                     # Verificar si hay información de ejes fijos
                     has_x = has_y = has_z = False
@@ -182,8 +185,10 @@ class VIEW3D_OT_VisualElementsOperator(Operator):
                 if group.name.startswith("constraint_"):
                     vertices_indices = [v.index for v in main_object.data.vertices 
                                        if group.index in [g.group for g in v.groups]]
-                    vertex_coordinates_global = [main_object.matrix_world @ main_object.data.vertices[i].co 
-                                               for i in vertices_indices]
+                    vertex_coordinates_global = [
+                        to_world_coordinates(main_object, main_object.data.vertices[i].co)
+                        for i in vertices_indices
+                    ]
                     
                     # Verificar si hay información de ejes fijos
                     has_x = has_y = has_z = False
@@ -208,8 +213,10 @@ class VIEW3D_OT_VisualElementsOperator(Operator):
                 if group.name.endswith("_load"):
                     vertices_indices = [v.index for v in main_object.data.vertices 
                                       if group.index in [g.group for g in v.groups]]
-                    vertex_coordinates_global = [main_object.matrix_world @ main_object.data.vertices[i].co 
-                                               for i in vertices_indices]
+                    vertex_coordinates_global = [
+                        to_world_coordinates(main_object, main_object.data.vertices[i].co)
+                        for i in vertices_indices
+                    ]
                     
                     # Obtener dirección de carga desde las propiedades personalizadas
                     orientation = 'RIGHT'  # Orientación por defecto


### PR DESCRIPTION
## Summary
- drop unused *run as admin* preference and UI option
- centralize helper utilities
- use helper for world coordinate transforms in operators
- simplify Fossils execution logic
- remove duplicate property registration

## Testing
- `python -m py_compile addon/*.py`
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_b_6852742d969c83319704fa978523f00e